### PR TITLE
Added getDeviation(), getFolderDeviations() and getGalleryFolders() methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ var dAmn = require('damn');
 
 dAmn.public(1234, 'cl13nt_s3cr3t', function(err, daClient) {
 	// Fetch today's daily deviations
-	da.getDailyDeviations(function(err, data) {
+	daClient.getDailyDeviations(function(err, data) {
 		// Output one title
 		console.log(data[0].title);
 	});
@@ -103,6 +103,58 @@ client.getWatchFeed(function(err, watchFeedItems) {
 **Parameters** :
 - `callback` : called with two parameters : *error* (`null` if none) and an array containing the watch feed items.
 
+### getDeviation(*deviationId*, *callback*)
+
+> Public endpoint
+
+Returns the details of a specific deviation :
+
+```javascript
+client.getDeviation("deviationId", function(err, data) {
+	console.log(data);
+});
+```
+
+**Parameters** :
+ - `deviationId` : the deviation id, as a *string*.
+ - `callback` : called with two parameters : *error* (`null` if none) and an object containing the deviation.
+
+### getFolderDeviations(*options*, *callback*)
+
+> Public endpoint
+
+Returns the list of a folder's deviations (all user's deviations if no `folderId` is given) :
+
+```javascript
+client.getFolderDeviations({
+	folderId: "folderId"
+}, function(err, data) {
+	console.log(data);
+});
+```
+
+**Parameters** :
+ - `options` : an object with optional `folderId` and `offset` keys.
+ - `callback` : called with two parameters : *error* (`null` if none) and an array containing the folder's deviations.
+
+### getGalleryFolders(*options*, *callback*)
+
+> Public endpoint
+
+Returns the list of an user's gallery folders :
+
+```javascript
+client.getGalleryFolders({
+	username: "username"
+}, function(err, folders) {
+	console.log(folders);
+});
+```
+
+**Parameters** :
+ - `options` : an object with a required `username` key and an optional `offset` key.
+ - `callback` : called with two parameters : *error* (`null` if none) and an array containing the specified user folders.
+
 ### placebo(*callback*)
 
 > Public endpoint
@@ -139,7 +191,7 @@ client.checkAccessToken(function(err, isValid) {
 	- [ ] jshint
 	- [ ] jscs
  - [ ] Add access to the following routes :
-	- [ ] `/deviation/{deviationid}` Fetch a deviation
+	- [X] `/deviation/{deviationid}` Fetch a deviation
 	- [ ] `/deviation/content` Fetch full data that is not included in the main devaition object
 	- [ ] `/browse/morelikethis` Fetch MoreLikeThis result for a seed deviation
 	- [ ] `/browse/newest` Browse newest deviations

--- a/client.js
+++ b/client.js
@@ -22,6 +22,43 @@ class Client {
 
 	// API calls
 
+	getDeviation(deviationId, cb) {
+		this.request('/deviation/' + deviationId, function(err, res, body) {
+			return cb(err, body);
+		});
+	}
+
+	getFolderDeviations(options, cb) {
+		options = options || {};
+		options.folderId = options.folderId || "";
+		options.offset = options.offset || 0;
+		this.request({
+			url: '/gallery/' + options.folderId,
+			qs: {
+				offset: options.offset,
+				mature_content: !this.matureFilter
+			}
+		}, function(err, res, body) {
+			return cb(err, body);
+		});
+	}
+
+	getGalleryFolders(options, cb) {
+		options = options || {};
+		options.offset = options.offset || 0;
+		this.request({
+			url: '/gallery/folders',
+			qs: {
+				username: options.username,
+				offset: options.offset,
+				calculate_size: true,
+				mature_content: !this.matureFilter
+			}
+		}, function(err, res, body) {
+			return cb(err, body);
+		});
+	}	
+
 	getDailyDeviations(cb) {
 		this.request({
 			url: '/browse/dailydeviations',


### PR DESCRIPTION
These 3 methods allows to browse through an user's gallery

I tried to "npm install" then "npm run test" but it gives me :

> ./node_modules/mocha/bin/mocha
> 
>  Client
>    1) "before all" hook
> 
>  Client generation
>    Client Credentials
>      ✓ should return a Client instance (354ms)
>    Implicit
>      2) should return a Client instance
> 
>  1 passing (5s)
>  2 failing
> 
>  1) Client "before all" hook:
>     Uncaught TypeError: Cannot read property '1' of null
>      at Request._callback (index.js:63:77)
>      at Request.self.callback (node_modules/request/request.js:187:22)
>      at Request.<anonymous> (node_modules/request/request.js:1044:10)
>      at IncomingMessage.<anonymous> (node_modules/request/request.js:965:12)
>      at endReadableNT (_stream_readable.js:913:12)
>      at _combinedTickCallback (internal/process/next_tick.js:74:11)
>      at process._tickCallback (internal/process/next_tick.js:98:9)
> 
>  2) Client generation Implicit should return a Client instance:
>     Uncaught TypeError: Cannot read property '1' of null
>      at Request._callback (index.js:63:77)
>      at Request.self.callback (node_modules/request/request.js:187:22)
>      at Request.<anonymous> (node_modules/request/request.js:1044:10)
>      at IncomingMessage.<anonymous> (node_modules/request/request.js:965:12)
>      at endReadableNT (_stream_readable.js:913:12)
>      at _combinedTickCallback (internal/process/next_tick.js:74:11)
>      at process._tickCallback (internal/process/next_tick.js:98:9)

I would add tests for these methods if you can help me with this :)
